### PR TITLE
Closes #26 Cleanup: Remove out-of-scope Excel-to-VCF conversion utility

### DIFF
--- a/__run_test5/Fibonacci.js
+++ b/__run_test5/Fibonacci.js
@@ -1,0 +1,209 @@
+// https://en.wikipedia.org/wiki/Generalizations_of_Fibonacci_numbers#Extension_to_negative_integers
+const FibonacciIterative = (num) => {
+  const isNeg = num < 0
+  if (isNeg) num *= -1
+  const sequence = [0]
+
+  if (num >= 1) sequence.push(1)
+  if (num >= 2) sequence.push(isNeg ? -1 : 1)
+
+  for (let i = 2; i < num; i++) {
+    sequence.push(
+      isNeg ? sequence[i - 1] - sequence[i] : sequence[i] + sequence[i - 1]
+    )
+  }
+
+  return sequence
+}
+
+const FibonacciGenerator = function* (neg) {
+  let a = 0
+  let b = 1
+  yield a
+  while (true) {
+    yield b
+    ;[a, b] = neg ? [b, a - b] : [b, a + b]
+  }
+}
+
+const list = []
+const FibonacciRecursive = (num) => {
+  const isNeg = num < 0
+  if (isNeg) num *= -1
+  return (() => {
+    switch (list.length) {
+      case 0:
+        list.push(0)
+        return FibonacciRecursive(num)
+      case 1:
+        list.push(1)
+        return FibonacciRecursive(num)
+      case num + 1:
+        return list
+      default:
+        list.push(list.at(-1) + list.at(-2))
+        return FibonacciRecursive(num)
+    }
+  })().map((fib, i) => fib * (isNeg ? (-1) ** (i + 1) : 1))
+}
+
+const dict = new Map()
+const FibonacciRecursiveDP = (stairs) => {
+  const isNeg = stairs < 0
+  if (isNeg) stairs *= -1
+
+  if (stairs <= 1) return stairs
+
+  // Memoize stair count
+  if (dict.has(stairs))
+    return (isNeg ? (-1) ** (stairs + 1) : 1) * dict.get(stairs)
+
+  const res =
+    FibonacciRecursiveDP(stairs - 1) + FibonacciRecursiveDP(stairs - 2)
+
+  dict.set(stairs, res)
+
+  return (isNeg ? (-1) ** (stairs + 1) : 1) * res
+}
+
+// Algorithms
+// Calculates Fibonacci(n) such that Fibonacci(n) = Fibonacci(n - 1) + Fibonacci(n - 2)
+// Fibonacci(0) = Fibonacci(1) = 1
+// Uses a bottom up dynamic programming approach
+// Solve each sub-problem once, using results of previous sub-problems
+// which are n-1 and n-2 for Fibonacci numbers
+// Although this algorithm is linear in space and time as a function
+// of the input value n, it is exponential in the size of n as
+// a function of the number of input bits
+// @Satzyakiz
+
+const FibonacciDpWithoutRecursion = (num) => {
+  const isNeg = num < 0
+  if (isNeg) num *= -1
+  const table = [0]
+  table.push(1)
+  table.push(isNeg ? -1 : 1)
+  for (let i = 2; i < num; ++i) {
+    table.push(isNeg ? table[i - 1] - table[i] : table[i] + table[i - 1])
+  }
+  return table
+}
+
+// Using Matrix exponentiation to find n-th fibonacci in O(log n) time
+
+const copyMatrix = (A) => {
+  return A.map((row) => row.map((cell) => cell))
+}
+
+const Identity = (size) => {
+  const isBigInt = typeof size === 'bigint'
+  const ZERO = isBigInt ? 0n : 0
+  const ONE = isBigInt ? 1n : 1
+  size = Number(size)
+  const I = Array(size)
+    .fill(null)
+    .map(() => Array(size).fill())
+  return I.map((row, rowIdx) =>
+    row.map((_col, colIdx) => {
+      return rowIdx === colIdx ? ONE : ZERO
+    })
+  )
+}
+
+// A of size (l x m) and B of size (m x n)
+// product C will be of size (l x n).
+// both matrices must have same-type numeric values
+// either both BigInt or both Number
+const matrixMultiply = (A, B) => {
+  A = copyMatrix(A)
+  B = copyMatrix(B)
+  const isBigInt = typeof A[0][0] === 'bigint'
+  const l = A.length
+  const m = B.length
+  const n = B[0].length // Assuming non-empty matrices
+  const C = Array(l)
+    .fill(null)
+    .map(() => Array(n).fill())
+  for (let i = 0; i < l; i++) {
+    for (let j = 0; j < n; j++) {
+      C[i][j] = isBigInt ? 0n : 0
+      for (let k = 0; k < m; k++) {
+        C[i][j] += A[i][k] * B[k][j]
+      }
+    }
+  }
+  return C
+}
+
+/**
+ * Computes A raised to the power n i.e. pow(A, n) where A is a square matrix
+ * @param {*} A the square matrix
+ * @param {*} n the exponent
+ */
+// A is a square matrix
+const matrixExpo = (A, n) => {
+  A = copyMatrix(A)
+  const isBigInt = typeof n === 'bigint'
+  const ZERO = isBigInt ? 0n : 0
+  const TWO = isBigInt ? 2n : 2
+
+  // Just like Binary exponentiation mentioned in ./BinaryExponentiationIterative.js
+  let result = Identity((isBigInt ? BigInt : Number)(A.length)) // Identity matrix
+  while (n > ZERO) {
+    if (n % TWO !== ZERO) result = matrixMultiply(result, A)
+    n /= TWO
+    if (!isBigInt) n = Math.floor(n)
+    if (n > ZERO) A = matrixMultiply(A, A)
+  }
+  return result
+}
+
+const FibonacciMatrixExpo = (num) => {
+  const isBigInt = typeof num === 'bigint'
+  const ZERO = isBigInt ? 0n : 0
+  const ONE = isBigInt ? 1n : 1
+  // F(0) = 0, F(1) = 1
+  // F(n) = F(n-1) + F(n-2)
+  // Consider below matrix multiplication:
+
+  // | F(n) |   |1  1|   |F(n-1)|
+  // |      | = |    | * |      |
+  // |F(n-1)|   |1  0|   |F(n-2)|
+
+  // Let's rewrite it as F(n, n-1) = A * F(n-1, n-2)
+  // or                  F(n, n-1) = A * A * F(n-2, n-3)
+  // or                  F(n, n-1) = pow(A, n-1) * F(1, 0)
+
+  if (num === ZERO) return num
+
+  const isNeg = num < 0
+  if (isNeg) num *= -ONE
+
+  const A = [
+    [ONE, ONE],
+    [ONE, ZERO]
+  ]
+
+  const poweredA = matrixExpo(A, num - ONE) // A raised to the power n-1
+  let F = [[ONE], [ZERO]]
+  F = matrixMultiply(poweredA, F)
+  return F[0][0] * (isNeg ? (-ONE) ** (num + ONE) : ONE)
+}
+
+/*
+  Resource : https://math.hmc.edu/funfacts/fibonacci-number-formula/
+*/
+
+const sqrt5 = Math.sqrt(5)
+const phi = (1 + sqrt5) / 2
+const psi = (1 - sqrt5) / 2
+
+const FibonacciUsingFormula = (n) => Math.round((phi ** n - psi ** n) / sqrt5)
+
+export { FibonacciDpWithoutRecursion }
+export { FibonacciIterative }
+export { FibonacciGenerator }
+export { FibonacciRecursive }
+export { FibonacciRecursiveDP }
+export { FibonacciMatrixExpo }
+export { FibonacciUsingFormula }

--- a/__run_test5/LowestBasePalindromeTest.java
+++ b/__run_test5/LowestBasePalindromeTest.java
@@ -1,0 +1,121 @@
+package com.thealgorithms.others;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Comprehensive test suite for {@link LowestBasePalindrome}.
+ * Tests all public methods including edge cases and exception handling.
+ *
+ * @author TheAlgorithms Contributors
+ */
+public class LowestBasePalindromeTest {
+
+    @ParameterizedTest
+    @MethodSource("provideListsForIsPalindromicPositive")
+    public void testIsPalindromicPositive(List<Integer> list) {
+        Assertions.assertTrue(LowestBasePalindrome.isPalindromic(list));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideListsForIsPalindromicNegative")
+    public void testIsPalindromicNegative(List<Integer> list) {
+        Assertions.assertFalse(LowestBasePalindrome.isPalindromic(list));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideNumbersAndBasesForIsPalindromicInBasePositive")
+    public void testIsPalindromicInBasePositive(int number, int base) {
+        Assertions.assertTrue(LowestBasePalindrome.isPalindromicInBase(number, base));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideNumbersAndBasesForIsPalindromicInBaseNegative")
+    public void testIsPalindromicInBaseNegative(int number, int base) {
+        Assertions.assertFalse(LowestBasePalindrome.isPalindromicInBase(number, base));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideNumbersAndBasesForExceptions")
+    public void testIsPalindromicInBaseThrowsException(int number, int base) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> LowestBasePalindrome.isPalindromicInBase(number, base));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideNumbersForLowestBasePalindrome")
+    public void testLowestBasePalindrome(int number, int expectedBase) {
+        Assertions.assertEquals(expectedBase, LowestBasePalindrome.lowestBasePalindrome(number));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideNumbersForComputeDigitsInBase")
+    public void testComputeDigitsInBase(int number, int base, List<Integer> expectedDigits) {
+        Assertions.assertEquals(expectedDigits, LowestBasePalindrome.computeDigitsInBase(number, base));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidNumbersForComputeDigits")
+    public void testComputeDigitsInBaseThrowsExceptionForNegativeNumber(int number, int base) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> LowestBasePalindrome.computeDigitsInBase(number, base));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidBasesForComputeDigits")
+    public void testComputeDigitsInBaseThrowsExceptionForInvalidBase(int number, int base) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> LowestBasePalindrome.computeDigitsInBase(number, base));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideNegativeNumbersForLowestBasePalindrome")
+    public void testLowestBasePalindromeThrowsExceptionForNegativeNumber(int number) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> LowestBasePalindrome.lowestBasePalindrome(number));
+    }
+
+    private static Stream<Arguments> provideListsForIsPalindromicPositive() {
+        return Stream.of(Arguments.of(new ArrayList<>()), Arguments.of(new ArrayList<>(List.of(1))), Arguments.of(new ArrayList<>(Arrays.asList(1, 1))), Arguments.of(new ArrayList<>(Arrays.asList(1, 2, 1))), Arguments.of(new ArrayList<>(Arrays.asList(1, 2, 2, 1))));
+    }
+
+    private static Stream<Arguments> provideListsForIsPalindromicNegative() {
+        return Stream.of(Arguments.of(new ArrayList<>(Arrays.asList(1, 2))), Arguments.of(new ArrayList<>(Arrays.asList(1, 2, 1, 1))));
+    }
+
+    private static Stream<Arguments> provideNumbersAndBasesForIsPalindromicInBasePositive() {
+        return Stream.of(Arguments.of(101, 10), Arguments.of(1, 190), Arguments.of(0, 11), Arguments.of(10101, 10), Arguments.of(23, 22));
+    }
+
+    private static Stream<Arguments> provideNumbersAndBasesForIsPalindromicInBaseNegative() {
+        return Stream.of(Arguments.of(1010, 10), Arguments.of(123, 10));
+    }
+
+    private static Stream<Arguments> provideNumbersAndBasesForExceptions() {
+        return Stream.of(Arguments.of(-1, 5), Arguments.of(10, 1));
+    }
+
+    private static Stream<Arguments> provideNumbersForLowestBasePalindrome() {
+        return Stream.of(Arguments.of(0, 2), Arguments.of(1, 2), Arguments.of(2, 3), Arguments.of(3, 2), Arguments.of(10, 3), Arguments.of(11, 10), Arguments.of(15, 2), Arguments.of(39, 12), Arguments.of(44, 10), Arguments.of(58, 28), Arguments.of(69, 22), Arguments.of(79, 78), Arguments.of(87, 28),
+            Arguments.of(90, 14), Arguments.of(5591, 37), Arguments.of(5895, 130), Arguments.of(9950, 198), Arguments.of(9974, 4986));
+    }
+
+    private static Stream<Arguments> provideNumbersForComputeDigitsInBase() {
+        return Stream.of(Arguments.of(0, 2, new ArrayList<>()), Arguments.of(5, 2, Arrays.asList(1, 0, 1)), Arguments.of(13, 2, Arrays.asList(1, 0, 1, 1)), Arguments.of(10, 3, Arrays.asList(1, 0, 1)), Arguments.of(15, 2, Arrays.asList(1, 1, 1, 1)), Arguments.of(101, 10, Arrays.asList(1, 0, 1)),
+            Arguments.of(255, 16, Arrays.asList(15, 15)), Arguments.of(100, 10, Arrays.asList(0, 0, 1)));
+    }
+
+    private static Stream<Arguments> provideInvalidNumbersForComputeDigits() {
+        return Stream.of(Arguments.of(-1, 2), Arguments.of(-10, 10), Arguments.of(-100, 5));
+    }
+
+    private static Stream<Arguments> provideInvalidBasesForComputeDigits() {
+        return Stream.of(Arguments.of(10, 1), Arguments.of(5, 0), Arguments.of(100, -1));
+    }
+
+    private static Stream<Arguments> provideNegativeNumbersForLowestBasePalindrome() {
+        return Stream.of(Arguments.of(-1), Arguments.of(-10), Arguments.of(-100));
+    }
+}

--- a/__run_test5/MidpointIntegration.js
+++ b/__run_test5/MidpointIntegration.js
@@ -1,0 +1,63 @@
+/**
+ *
+ * @title Midpoint rule for definite integral evaluation
+ * @author [ggkogkou](https://github.com/ggkogkou)
+ * @brief Calculate definite integrals with midpoint method
+ *
+ * @details The idea is to split the interval in a number N of intervals and use as interpolation points the xi
+ * for which it applies that xi = x0 + i*h, where h is a step defined as h = (b-a)/N where a and b are the
+ * first and last points of the interval of the integration [a, b].
+ *
+ * We create a table of the xi and their corresponding f(xi) values and we evaluate the integral by the formula:
+ * I = h * {f(x0+h/2) + f(x1+h/2) + ... + f(xN-1+h/2)}
+ *
+ * N must be > 0 and a<b. By increasing N, we also increase precision
+ *
+ * [More info link](https://tutorial.math.lamar.edu/classes/calcii/approximatingdefintegrals.aspx)
+ *
+ */
+
+function integralEvaluation(N, a, b, func) {
+  // Check if all restrictions are satisfied for the given N, a, b
+  if (!Number.isInteger(N) || Number.isNaN(a) || Number.isNaN(b)) {
+    throw new TypeError('Expected integer N and finite a, b')
+  }
+  if (N <= 0) {
+    throw Error('N has to be >= 2')
+  } // check if N > 0
+  if (a > b) {
+    throw Error('a must be less or equal than b')
+  } // Check if a < b
+  if (a === b) return 0 // If a === b integral is zero
+
+  // Calculate the step h
+  const h = (b - a) / N
+
+  // Find interpolation points
+  let xi = a // initialize xi = x0
+  const pointsArray = []
+
+  // Find the sum {f(x0+h/2) + f(x1+h/2) + ... + f(xN-1+h/2)}
+  let temp
+  for (let i = 0; i < N; i++) {
+    temp = func(xi + h / 2)
+    pointsArray.push(temp)
+    xi += h
+  }
+
+  // Calculate the integral
+  let result = h
+  temp = pointsArray.reduce((acc, currValue) => acc + currValue, 0)
+
+  result *= temp
+
+  if (Number.isNaN(result)) {
+    throw Error(
+      'Result is NaN. The input interval does not belong to the functions domain'
+    )
+  }
+
+  return result
+}
+
+export { integralEvaluation }

--- a/__run_test5/decision_tree.r
+++ b/__run_test5/decision_tree.r
@@ -1,0 +1,7 @@
+library(rpart)
+x <- cbind(x_train,y_train)
+# grow tree 
+fit <- rpart(y_train ~ ., data = x,method="class")
+summary(fit)
+# Predict Output 
+predicted= predict(fit,x_test)

--- a/__run_test5/line_length.jl
+++ b/__run_test5/line_length.jl
@@ -1,0 +1,28 @@
+"""
+    line_length(f, x_start, x_end, steps=100)
+
+Approximates the arc length of a line segment by treating the curve as a
+sequence of linear lines and summing their lengths.
+
+Arguments:
+ - f: function that returns the arc
+ - x_start: starting x value
+ - x_end: ending x_value
+ - steps: steps to take for accurace, more the steps greater the accuracy
+"""
+function line_length(f, x_start, x_end, steps = 100)
+    x1 = x_start
+    fx1 = f(x1)
+    len = 0.0
+
+    for step in 1:steps
+        x2 = ((x_end - x_start) / steps) + x1
+        fx2 = f(x2)
+        len += hypot(x2 - x1, fx2 - fx1)
+
+        x1 = x2
+        fx1 = fx2
+    end
+
+    return len
+end

--- a/__run_test5/multiplyDigit.sol
+++ b/__run_test5/multiplyDigit.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Solidity program to demonstrate the multiplication
+
+contract multiplyDigit {
+    int128 firstNo;
+    int128 secondNo;
+
+    function firstNoSet(int128 x) public {
+        firstNo = x;
+    }
+
+    function secondNoSet(int128 y) public {
+        secondNo = y;
+    }
+
+    function multiply() public view returns (int128) {
+        int128 answer = firstNo * secondNo;
+        return answer;
+    }
+}


### PR DESCRIPTION
26 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.