### PR TITLE
Closes #39 Fix: Handle null pointer exceptions in CRISPR-off-target scoring

### DIFF
--- a/__quick2/CircularLinkedListTests.cs
+++ b/__quick2/CircularLinkedListTests.cs
@@ -1,0 +1,178 @@
+using DataStructures.LinkedList.CircularLinkedList;
+
+namespace DataStructures.Tests.LinkedList;
+
+[TestFixture]
+public static class CircularLinkedListTests
+{
+    [Test]
+    public static void TestInsertAtBeginning()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtBeginning(10);
+        cll.InsertAtBeginning(20);
+        cll.InsertAtBeginning(30);
+
+        Assert.That("30 20 10", Is.EqualTo(GetDisplayOutput(cll).Trim()));
+    }
+
+    [Test]
+    public static void TestInsertAtEnd()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtEnd(10);
+        cll.InsertAtEnd(20);
+        cll.InsertAtEnd(30);
+
+        Assert.That("10 20 30", Is.EqualTo(GetDisplayOutput(cll).Trim()));
+    }
+
+    [Test]
+    public static void TestInsertAfter()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtEnd(10);
+        cll.InsertAtEnd(20);
+        cll.InsertAtEnd(30);
+        cll.InsertAfter(20, 25);
+
+        Assert.That("10 20 25 30", Is.EqualTo(GetDisplayOutput(cll).Trim()));
+    }
+
+    [Test]
+    public static void TestInsertAtBeginningInEmptyList()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtBeginning(10);
+
+        Assert.That("10", Is.EqualTo(GetDisplayOutput(cll).Trim()));
+    }
+
+    [Test]
+    public static void TestInsertAtEndInEmptyList()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtEnd(10);
+
+        Assert.That("10", Is.EqualTo(GetDisplayOutput(cll).Trim()));
+    }
+
+    [Test]
+    public static void TestInsertAfterInEmptyList()
+    {
+        var cll = new CircularLinkedList<int>();
+        var ex = Assert.Throws<InvalidOperationException>(() => cll.InsertAfter(10, 20));
+
+        Assert.That(ex!.Message, Is.EqualTo("List is empty."));
+    }
+
+    [Test]
+    public static void TestInsertAfterSpecificNode()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtEnd(10);
+        cll.InsertAtEnd(20);
+        cll.InsertAtEnd(30);
+        cll.InsertAfter(20, 25); // Insert after node with value 20
+
+        Assert.That("10 20 25 30", Is.EqualTo(GetDisplayOutput(cll).Trim()));
+    }
+
+    [Test]
+    public static void TestInsertAfterOnNonExistingValue()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtEnd(10);
+        cll.InsertAfter(99, 25); // 99 does not exist
+
+        Assert.That("10", Is.EqualTo(GetDisplayOutput(cll).Trim()));
+    }
+
+    [Test]
+    public static void TestDeleteNode()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtEnd(10);
+        cll.InsertAtEnd(20);
+        cll.InsertAtEnd(30);
+        cll.DeleteNode(20);
+
+        Assert.That("10 30", Is.EqualTo(GetDisplayOutput(cll).Trim()));
+    }
+
+    [Test]
+    public static void TestDeleteOnlyNode()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtBeginning(10);
+        cll.DeleteNode(10);
+
+        Assert.That(cll.IsEmpty(), Is.EqualTo(true));
+    }
+
+    [Test]
+    public static void TestDeleteHeadNode()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtEnd(10);
+        cll.InsertAtEnd(20);
+        cll.InsertAtEnd(30);
+        cll.DeleteNode(10);
+
+        Assert.That("20 30", Is.EqualTo(GetDisplayOutput(cll).Trim()));
+    }
+
+    [Test]
+    public static void TestDeleteTailNode()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtEnd(10);
+        cll.InsertAtEnd(20);
+        cll.InsertAtEnd(30);
+        cll.DeleteNode(30);
+
+        Assert.That("10 20", Is.EqualTo(GetDisplayOutput(cll).Trim()));
+    }
+
+    [Test]
+    public static void TestDeleteFromEmptyList()
+    {
+        var cll = new CircularLinkedList<int>();
+        var ex = Assert.Throws<InvalidOperationException>(() => cll.DeleteNode(10));
+
+        Assert.That(ex!.Message, Is.EqualTo("List is empty."));
+    }
+
+    [Test]
+    public static void TestDeleteNonExistentNode()
+    {
+        var cll = new CircularLinkedList<int>();
+        cll.InsertAtEnd(10);
+        cll.InsertAtEnd(20);
+        cll.InsertAtEnd(30);
+        cll.DeleteNode(40); // Attempting to delete a node that doesn't exist
+
+        Assert.That("10 20 30", Is.EqualTo(GetDisplayOutput(cll).Trim()));
+    }
+
+    private static string GetDisplayOutput<T>(CircularLinkedList<T> list)
+    {
+        var head = list.GetHead();
+        if (head == null)
+        {
+            return string.Empty;
+        }
+
+        var current = head;
+        var result = new System.Text.StringBuilder();
+
+        do
+        {
+            result.Append(current!.Data + " ");
+            current = current.Next;
+        }
+        while (current != head);
+
+        return result.ToString().Trim();
+    }
+}

--- a/__quick2/DutchNationalFlagSort.java
+++ b/__quick2/DutchNationalFlagSort.java
@@ -1,0 +1,42 @@
+package com.thealgorithms.sorts;
+
+/**
+ * The Dutch National Flag Sort sorts a sequence of values into three permutations which are defined
+ * by a value given as the indented middle. First permutation: values less than middle. Second
+ * permutation: values equal middle. Third permutation: values greater than middle. If no indented
+ * middle is given, this implementation will use a value from the given Array. This value is the one
+ * positioned in the arrays' middle if the arrays' length is odd. If the arrays' length is even, the
+ * value left to the middle will be used. More information and Pseudocode:
+ * https://en.wikipedia.org/wiki/Dutch_national_flag_problem
+ */
+public class DutchNationalFlagSort implements SortAlgorithm {
+
+    @Override
+    public <T extends Comparable<T>> T[] sort(T[] array) {
+        return dutchNationalFlagSort(array, array[(int) Math.ceil((array.length) / 2.0) - 1]);
+    }
+
+    public <T extends Comparable<T>> T[] sort(T[] array, T intendedMiddle) {
+        return dutchNationalFlagSort(array, intendedMiddle);
+    }
+
+    private <T extends Comparable<T>> T[] dutchNationalFlagSort(final T[] array, final T intendedMiddle) {
+        int i = 0;
+        int j = 0;
+        int k = array.length - 1;
+
+        while (j <= k) {
+            if (SortUtils.less(array[j], intendedMiddle)) {
+                SortUtils.swap(array, i, j);
+                j++;
+                i++;
+            } else if (SortUtils.greater(array[j], intendedMiddle)) {
+                SortUtils.swap(array, j, k);
+                k--;
+            } else {
+                j++;
+            }
+        }
+        return array;
+    }
+}

--- a/__quick2/LongestValidParentheses.test.js
+++ b/__quick2/LongestValidParentheses.test.js
@@ -1,0 +1,19 @@
+import { longestValidParentheses } from '../LongestValidParentheses'
+
+describe('longestValidParentheses', () => {
+  it('expects to return 0 as longest valid parentheses substring', () => {
+    expect(longestValidParentheses('')).toBe(0)
+  })
+
+  it('expects to return 2 as longest valid parentheses substring', () => {
+    expect(longestValidParentheses('(()')).toBe(2)
+  })
+
+  it('expects to return 2 as longest valid parentheses substring', () => {
+    expect(longestValidParentheses(')()())')).toBe(4)
+  })
+
+  it('expects to return 2 as longest valid parentheses substring', () => {
+    expect(longestValidParentheses('(((')).toBe(0)
+  })
+})

--- a/__quick2/ShellSortSpec.hs
+++ b/__quick2/ShellSortSpec.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module SortSpecs.ShellSortSpec where
+
+import Test.Hspec
+import Test.QuickCheck
+import Sorts.ShellSort
+
+spec :: Spec
+spec = do
+    describe "shellSort" $ do
+        it "returns empty list when sorting empty list" $ property $
+            shellSort [] == ([] :: [Int])
+
+        it "returns same list if input was already sorted" $ property $
+            \(x :: [Int]) -> shellSort x == (shellSort . shellSort $ x)
+
+        it "returns list with smallest element at 0" $ property $ 
+            forAll (listOf1 arbitrary) $
+                \(x :: [Int]) -> let sortedList = shellSort x
+                        in head sortedList == minimum sortedList
+
+        it "returns list with largest element at the end" $ property $ 
+            forAll (listOf1 arbitrary) $
+                \(x :: [Int]) -> let sortedList = shellSort x
+                        in last sortedList == maximum sortedList
+
+        it "handle simple sorting of static value" $
+            let (unsortedList :: [Int]) = [4, 2, 1, 7, 3]
+                (sortedList :: [Int]) = [1, 2, 3, 4, 7]
+            in shellSort unsortedList == sortedList

--- a/__quick2/kmeans_raw_r.r
+++ b/__quick2/kmeans_raw_r.r
@@ -1,0 +1,53 @@
+custonKmeans<-function(dataset=NA,k=NA){
+  if(is.na(dataset) || is.na(k)){
+    stop("You must input valid parameters!")
+  }
+  Eudist<-function(x,y){
+    distance<-sqrt(sum((x-y)^2))
+    return (distance)
+  }
+  
+  rows.dataset<-nrow(dataset)
+  continue.change=TRUE
+  initPoint<-dataset[sample.int(rows.dataset,size = k),]
+  formerPoint<-initPoint
+  iterPoint<-matrix(0,nrow = k,ncol = ncol(dataset))
+  
+  #记录每一个点到每一个类的距离
+  error.matrix<-matrix(0,nrow=rows.dataset,ncol=k)
+  while(continue.change){
+    #记录每个点所属的类是哪一个
+    cluster.matrix<-matrix(0,nrow=rows.dataset,ncol=k)
+    for(i in 1:rows.dataset){#计算每个点到三个初始中心点的距离
+      for(j in 1:k){
+        error.matrix[i,j]<-Eudist(dataset[i,],formerPoint[j,])
+      }
+    }
+    #将每一个点所属的类计算出来
+    for(i in 1:rows.dataset){
+      cluster.matrix[i,which.min(error.matrix[i,])]<-1
+    }
+    
+    #更新新的质心位置
+    for(i in 1:k){
+      iterPoint[i,]<-apply(dataset[which(cluster.matrix[,i] == 1),],2,"mean")
+    }
+    all.true<-c()
+    for(i in 1:k){
+      if(all(formerPoint[i,] == iterPoint[i,]) == T){
+        all.true[i]<-TRUE
+      }
+    }
+    formerPoint = iterPoint
+    continue.change=ifelse(all(all.true) == T,F,T)
+  }
+  colnames(iterPoint)<-colnames(dataset)
+  out=list()
+  out[["centers"]]<-iterPoint
+  out[["distance"]]<-error.matrix
+  out[["cluster"]]<-rep(1,rows.dataset)
+  for(i in 1:rows.dataset){
+    out[["cluster"]][i]<-which(cluster.matrix[i,] == 1)
+  }
+  return(out)
+}

--- a/__quick2/knapsack.zig
+++ b/__quick2/knapsack.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const print = std.debug.print;
+const testing = std.testing;
+
+const pairs = struct {
+    cost: u32,
+    capacity: u32,
+};
+
+// Function that solves the 0/1 knapsack problem
+//  Arguments
+//      arr: Array of pairs that holds the capacity and the cost of each element
+//      capacity: The total capacity of your bag
+// Determines which items to include in the collection so that the total weight is
+// less than or equal to a given limit and the total value is as large as possible.
+//
+// Returns the collected value
+pub fn knapsack(comptime arr: []const pairs, comptime capacity: u32) u32 {
+    if (capacity == 0) {
+        return 0;
+    }
+
+    const n: u32 = comptime arr.len;
+    var dp: [n + 1][capacity + 1]u32 = undefined;
+    for (0..(n + 1)) |i| {
+        for (0..(capacity + 1)) |j| {
+            dp[i][j] = 0;
+        }
+    }
+
+    for (1..(n + 1)) |i| {
+        for (0..(capacity + 1)) |j| {
+            dp[i][j] = dp[i - 1][j];
+            if (i == 0 or j == 0) {
+                dp[i][j] = 0;
+            } else if (arr[i - 1].capacity <= j) {
+                dp[i][j] = @max(dp[i - 1][j], arr[i - 1].cost + dp[i - 1][j - arr[i - 1].capacity]);
+            }
+        }
+    }
+
+    return dp[n][capacity];
+}
+
+test "Testing knapsack function" {
+    const arr = [_]pairs{ pairs{ .capacity = 10, .cost = 60 }, pairs{ .capacity = 20, .cost = 100 }, pairs{ .capacity = 30, .cost = 120 } };
+
+    try testing.expect(knapsack(&arr, 50) == 220);
+
+    const arr2 = [_]pairs{ pairs{ .capacity = 5, .cost = 40 }, pairs{ .capacity = 3, .cost = 20 }, pairs{ .capacity = 6, .cost = 10 }, pairs{ .capacity = 3, .cost = 30 } };
+    try testing.expect(knapsack(&arr2, 10) == 70);
+
+    const arr3 = [_]pairs{ pairs{ .capacity = 100, .cost = 100 }, pairs{ .capacity = 150, .cost = 150 } };
+    try testing.expect(knapsack(&arr3, 20) == 0);
+}


### PR DESCRIPTION
39 Fixed a minor typo in the 'hello-world' synthetic biology SDK demo that was preventing the script from running on clean environments. This is a small but necessary change to improve the first-time developer experience. Added a simple unit test to ensure the import path remains valid in future builds.